### PR TITLE
chore: Bump version to 1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 via [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning).
 
+## [1.0.0-rc.2] — 2026-03-13
+
+### Added
+
+- **InterpreterResult\<TEvent\>**: Pre-allocated `Empty` result for zero-alloc interpreter fast paths (analogous to `PipelineResult.Ok`)
+- **Documentation**: [Zero-alloc domain modeling guide](docs/guides/zero-alloc-domain-modeling.md) — eliminating heap allocations on hot paths
+- **Benchmarks**: Record-based zero-alloc benchmark domain proving 0 B allocation on lean dispatch
+
+### Changed
+
+- **Benchmarks**: Existing interpreters updated to use `InterpreterResult<TEvent>.Empty`
+- **Copyright**: Updated to 2025-2026
+
+### Testing
+
+- Added 64 new tests (119 → 183 total):
+  - `OptionTests.cs`: 42 tests covering the full `Option<T>` public API (previously zero coverage)
+  - `RuntimeTests.cs`: 22 new combinator tests for Observer and Interpreter pipelines
+
 ## [1.0.0-rc.1] — 2026-03-09
 
 ### Added
@@ -18,14 +37,14 @@ via [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning).
 - **Option type**: `Option<TValue>` readonly struct
 - **Observer pipeline**: Monadic combinators — `Then`, `Where`, `Select`, `Catch`, `Combine`
 - **Interpreter pipeline**: Monadic combinators — `Then`, `Where`, `Select`, `Catch`
-- **InterpreterResult\<TEvent\>**: Pre-allocated `Empty` result for zero-alloc interpreter fast paths (analogous to `PipelineResult.Ok`)
 - **Diagnostics**: `AutomatonDiagnostics` with OpenTelemetry-compatible `ActivitySource` tracing
 - **Production guarantees**: Thread-safe dispatch (SemaphoreSlim), cancellation support, bounded feedback loops (max 64 depth)
-- **Documentation**: Concepts, tutorials, how-to guides, API reference, ADRs (including [zero-alloc domain modeling guide](docs/guides/zero-alloc-domain-modeling.md))
-- **Benchmarks**: BenchmarkDotNet suite for kernel operations with interface-based and record-based domain variants
+- **Documentation**: Concepts, tutorials, how-to guides, API reference, ADRs
+- **Benchmarks**: BenchmarkDotNet suite for kernel operations
 
 ### Origin
 
 This release is the extraction of the kernel from [MCGPPeters/Automaton](https://github.com/MCGPPeters/Automaton) into the Picea ecosystem. The kernel code is identical — only the root namespace changed from `Automaton` to `Picea`. All type names (`Automaton<>`, `AutomatonRuntime<>`, `AutomatonDiagnostics`, etc.) are preserved.
 
+[1.0.0-rc.2]: https://github.com/picea/picea/releases/tag/v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/picea/picea/releases/tag/v1.0.0-rc.1

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0-rc.1",
+  "version": "1.0-rc.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
### What

Bumps `version.json` from `1.0-rc.1` to `1.0-rc.2` and updates `CHANGELOG.md` with a dedicated rc.2 section separating new additions from the original rc.1 content.

### Why

The `v1.0.0-rc.2` tag has already been pushed. This PR lands the version metadata and changelog on `main` to match.

### Testing

Metadata-only change — no code affected. Build and tests unaffected.