### PR TITLE
feat: add hash-chain integrity layer for event log

### DIFF
--- a/Picea.Tests/EventLogTests.cs
+++ b/Picea.Tests/EventLogTests.cs
@@ -203,6 +203,155 @@ public sealed class EventLogTests
         await Assert.That(log[0].Event is CounterEvent.Increment).IsTrue();
     }
 
+    [Test]
+    public async Task HashChain_CreateFactory_ProducesComposableObserverAndTracksCurrentHash()
+    {
+        var (observer, log) = EventLog.CreateHashChain<CounterState, CounterEvent, CounterEffect>();
+        var baselineHash = log.CurrentHash;
+
+        var runtime = new AutomatonRuntime<Counter, CounterState, CounterEvent, CounterEffect, Unit>(
+            new CounterState(0),
+            observer,
+            _ => InterpreterResult<CounterEvent>.Empty);
+
+        _ = await runtime.Dispatch(new CounterEvent.Increment());
+        _ = await runtime.Dispatch(new CounterEvent.Decrement());
+
+        await Assert.That(log.Count).IsEqualTo(2);
+        await Assert.That(log.CurrentHash).IsNotEqualTo(baselineHash);
+        await Assert.That(log.VerifyChain()).IsTrue();
+    }
+
+    [Test]
+    public async Task HashChain_VerifyRangeAndAnchor_WorkForValidLog()
+    {
+        var log = CreateDeltaHashChainLog();
+
+        await Assert.That(log.VerifyChain()).IsTrue();
+        await Assert.That(log.VerifyRange(2, 3)).IsTrue();
+        await Assert.That(log.VerifyAnchor(log.AnchorHash)).IsTrue();
+        await Assert.That(log.VerifyAnchor("not-the-anchor")).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_EmptyLog_VerifyAnchorRequiresAnchorMatch()
+    {
+        var (_, log) = EventLog.CreateHashChain<Unit, DeltaEvent, Unit>();
+
+        await Assert.That(log.VerifyChain()).IsTrue();
+        await Assert.That(log.VerifyAnchor(log.AnchorHash)).IsTrue();
+        await Assert.That(log.VerifyAnchor("not-the-anchor")).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_VerifyRange_RejectsInvalidBoundsAndMissingSequences()
+    {
+        var log = CreateDeltaHashChainLog();
+
+        await Assert.That(log.VerifyRange(0, 1)).IsFalse();
+        await Assert.That(log.VerifyRange(3, 2)).IsFalse();
+        await Assert.That(log.VerifyRange(1, 99)).IsFalse();
+        await Assert.That(log.VerifyRange(99, 100)).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_TamperDetection_ModifiedEntryFailsVerification()
+    {
+        var serializer = new JsonEventSerializer();
+        var source = CreateDeltaHashChainLog(serializer);
+
+        var entries = source.Entries.ToArray();
+        entries[1] = entries[1] with { Event = new DeltaEvent(999) };
+
+        var loaded = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(entries), serializer);
+
+        await Assert.That(loaded.VerifyChain()).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_TamperDetection_ModifiedEntryFailsRangeAndAnchorVerification()
+    {
+        var serializer = new JsonEventSerializer();
+        var source = CreateDeltaHashChainLog(serializer);
+
+        var entries = source.Entries.ToArray();
+        entries[1] = entries[1] with { Event = new DeltaEvent(999) };
+
+        var loaded = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(entries), serializer);
+
+        await Assert.That(loaded.VerifyRange(1, 3)).IsFalse();
+        await Assert.That(loaded.VerifyAnchor(source.AnchorHash)).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_TamperDetection_InsertedDeletedAndReorderedEntriesFailVerification()
+    {
+        var serializer = new JsonEventSerializer();
+        var source = CreateDeltaHashChainLog(serializer);
+        var original = source.Entries.ToArray();
+
+        var inserted = new[]
+        {
+            original[0],
+            original[1],
+            original[2],
+            new HashChainLogEntry<DeltaEvent>(99, original[2].Timestamp.AddMinutes(1), new DeltaEvent(7), original[2].Hash, original[2].Hash)
+        };
+
+        var deleted = new[]
+        {
+            original[0],
+            original[2]
+        };
+
+        var reordered = new[]
+        {
+            original[0],
+            original[2],
+            original[1]
+        };
+
+        var insertedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(inserted), serializer);
+        var deletedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(deleted), serializer);
+        var reorderedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(reordered), serializer);
+
+        await Assert.That(insertedLog.VerifyChain()).IsFalse();
+        await Assert.That(deletedLog.VerifyChain()).IsFalse();
+        await Assert.That(reorderedLog.VerifyChain()).IsFalse();
+    }
+
+    [Test]
+    public async Task HashChain_SaveLoad_RoundTripsAndPreservesReplayParity()
+    {
+        var serializer = new JsonEventSerializer();
+        var source = CreateDeltaHashChainLog(serializer);
+        var path = Path.Join(Path.GetTempPath(), $"picea-hash-chain-log-{Guid.NewGuid():N}.jsonl");
+
+        try
+        {
+            await source.SaveAsync(path);
+
+            var loaded = await EventLog.LoadHashChainAsync<DeltaEvent>(path, serializer);
+            var sourceAsEventLog = source.AsEventLog();
+            var loadedAsEventLog = loaded.AsEventLog();
+
+            await Assert.That(loaded.Count).IsEqualTo(source.Count);
+            await Assert.That(loaded.VerifyChain()).IsTrue();
+            await Assert.That(loaded.CurrentHash).IsEqualTo(source.CurrentHash);
+
+            var sourceReplay = sourceAsEventLog.Replay<DeltaAutomaton, int, Unit, Unit>(default);
+            var loadedReplay = loadedAsEventLog.Replay<DeltaAutomaton, int, Unit, Unit>(default);
+
+            await Assert.That(sourceReplay).IsEqualTo(6);
+            await Assert.That(loadedReplay).IsEqualTo(sourceReplay);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
     private static async ValueTask<EventLog<CounterEvent>> CreateCounterEventLog()
     {
         var (observer, log) = EventLog.Create<CounterState, CounterEvent, CounterEffect>();
@@ -217,6 +366,30 @@ public sealed class EventLogTests
         _ = await runtime.Dispatch(new CounterEvent.Decrement());
 
         return log;
+    }
+
+    private static HashChainEventLog<DeltaEvent> CreateDeltaHashChainLog(EventSerializer? serializer = null)
+    {
+        var (_, log) = EventLog.CreateHashChain<Unit, DeltaEvent, Unit>(serializer: serializer);
+
+        log.Append(new DeltaEvent(2), new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero));
+        log.Append(new DeltaEvent(-1), new DateTimeOffset(2026, 4, 6, 10, 1, 0, TimeSpan.Zero));
+        log.Append(new DeltaEvent(5), new DateTimeOffset(2026, 4, 6, 10, 2, 0, TimeSpan.Zero));
+
+        return log;
+    }
+
+    private static HashChainLogStorage<DeltaEvent> HashChainStorage(IReadOnlyList<HashChainLogEntry<DeltaEvent>> entries) =>
+        new(
+            SaveEntries: static (_, _) => ValueTask.CompletedTask,
+            LoadEntries: _ => ToAsync(entries));
+
+    private static async IAsyncEnumerable<HashChainLogEntry<DeltaEvent>> ToAsync(IReadOnlyList<HashChainLogEntry<DeltaEvent>> entries)
+    {
+        await ValueTask.CompletedTask;
+
+        for (var i = 0; i < entries.Count; i++)
+            yield return entries[i];
     }
 
     public readonly record struct DeltaEvent(int Delta);

--- a/Picea.Tests/EventLogTests.cs
+++ b/Picea.Tests/EventLogTests.cs
@@ -311,13 +311,14 @@ public sealed class EventLogTests
             original[1]
         };
 
-        var insertedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(inserted), serializer);
-        var deletedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(deleted), serializer);
-        var reorderedLog = await HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(reordered), serializer);
+        await Assert.That(() => HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(inserted), serializer).AsTask())
+            .ThrowsExactly<InvalidDataException>();
 
-        await Assert.That(insertedLog.VerifyChain()).IsFalse();
-        await Assert.That(deletedLog.VerifyChain()).IsFalse();
-        await Assert.That(reorderedLog.VerifyChain()).IsFalse();
+        await Assert.That(() => HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(deleted), serializer).AsTask())
+            .ThrowsExactly<InvalidDataException>();
+
+        await Assert.That(() => HashChainEventLog<DeltaEvent>.LoadAsync(HashChainStorage(reordered), serializer).AsTask())
+            .ThrowsExactly<InvalidDataException>();
     }
 
     [Test]

--- a/Picea/EventLog.cs
+++ b/Picea/EventLog.cs
@@ -143,6 +143,22 @@ public static class EventLog
         EventLog<TEvent>.Create<TState, TEffect>(timestampFactory);
 
     /// <summary>
+    /// Creates an append-only hash-chained event log together with a composable observer.
+    /// </summary>
+    /// <typeparam name="TState">The runtime state type.</typeparam>
+    /// <typeparam name="TEvent">The runtime event type.</typeparam>
+    /// <typeparam name="TEffect">The runtime effect type.</typeparam>
+    /// <param name="serializer">Optional serializer used for hash payload generation and persistence.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    /// <param name="timestampFactory">Optional timestamp factory used for each append.</param>
+    /// <returns>A tuple containing the observer and its backing hash-chained event log.</returns>
+    public static (Observer<TState, TEvent, TEffect> Observer, HashChainEventLog<TEvent> Log) CreateHashChain<TState, TEvent, TEffect>(
+        EventSerializer? serializer = null,
+        HashChainOptions? hashing = null,
+        Func<DateTimeOffset>? timestampFactory = null) =>
+        HashChainEventLog<TEvent>.Create<TState, TEffect>(serializer, hashing, timestampFactory);
+
+    /// <summary>
     /// Loads an event log from a JSON Lines file.
     /// </summary>
     /// <typeparam name="TEvent">The event type.</typeparam>
@@ -155,6 +171,22 @@ public static class EventLog
         EventSerializer serializer,
         CancellationToken cancellationToken = default) =>
         EventLog<TEvent>.LoadAsync(path, serializer, cancellationToken);
+
+    /// <summary>
+    /// Loads a hash-chained event log from a JSON Lines file.
+    /// </summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="path">The path to the JSONL file.</param>
+    /// <param name="serializer">The serializer capability.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    /// <param name="cancellationToken">Cancellation token for asynchronous loading.</param>
+    /// <returns>The loaded hash-chained event log.</returns>
+    public static ValueTask<HashChainEventLog<TEvent>> LoadHashChainAsync<TEvent>(
+        string path,
+        EventSerializer serializer,
+        HashChainOptions? hashing = null,
+        CancellationToken cancellationToken = default) =>
+        HashChainEventLog<TEvent>.LoadAsync(path, serializer, hashing, cancellationToken);
 }
 
 /// <summary>
@@ -412,6 +444,23 @@ public sealed class EventLog<TEvent>
         entries.Sort(static (left, right) => left.SequenceNumber.CompareTo(right.SequenceNumber));
 
         return new EventLog<TEvent>(entries, nextSequence);
+    }
+
+    internal static EventLog<TEvent> FromEntries(IReadOnlyList<LogEntry<TEvent>> orderedEntries)
+    {
+        var entries = orderedEntries.Count is 0 ? [] : new List<LogEntry<TEvent>>(orderedEntries.Count);
+        var nextSequenceNumber = 1L;
+
+        for (var i = 0; i < orderedEntries.Count; i++)
+        {
+            var entry = orderedEntries[i];
+            entries.Add(entry);
+
+            if (entry.SequenceNumber >= nextSequenceNumber)
+                nextSequenceNumber = entry.SequenceNumber + 1;
+        }
+
+        return new EventLog<TEvent>(entries, nextSequenceNumber);
     }
 
     private LogEntry<TEvent>[] SnapshotOrderedBySequence()

--- a/Picea/HashChainEventLog.cs
+++ b/Picea/HashChainEventLog.cs
@@ -119,6 +119,10 @@ public static class HashChainLogStorage
 /// Append-only hash-chained event log with replay, verification, and persistence APIs.
 /// </summary>
 /// <typeparam name="TEvent">The event type captured by the log.</typeparam>
+/// <remarks>
+/// Hash-chain verification assumes deterministic event serialization for hashing.
+/// Use a stable serializer configuration for the lifetime of a hash-chained log.
+/// </remarks>
 public sealed class HashChainEventLog<TEvent>
 {
     private readonly Lock _sync = new();
@@ -269,6 +273,10 @@ public sealed class HashChainEventLog<TEvent>
     /// <summary>
     /// Converts this hash-chained log into a standard event log snapshot.
     /// </summary>
+    /// <remarks>
+    /// Call <see cref="VerifyChain"/> or <see cref="VerifyAnchor"/> before replaying when
+    /// tamper-evidence is required. This method does not perform verification implicitly.
+    /// </remarks>
     /// <returns>A snapshot-compatible event log.</returns>
     public EventLog<TEvent> AsEventLog()
     {
@@ -383,6 +391,7 @@ public sealed class HashChainEventLog<TEvent>
 
         var entries = new List<HashChainLogEntry<TEvent>>();
         var sequenceNumbers = new HashSet<long>();
+        long previousSequenceNumber = 0;
 
         await foreach (var entry in storage.LoadEntries(cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -393,6 +402,19 @@ public sealed class HashChainEventLog<TEvent>
 
             if (!sequenceNumbers.Add(entry.SequenceNumber))
                 throw new InvalidDataException($"Duplicate sequence number '{entry.SequenceNumber}' detected while loading the hash-chained event log.");
+
+            if (previousSequenceNumber is 0)
+            {
+                if (entry.SequenceNumber is not 1)
+                    throw new InvalidDataException("Invalid first sequence number. Hash-chained logs must start at sequence number 1.");
+            }
+            else if (entry.SequenceNumber != previousSequenceNumber + 1)
+            {
+                throw new InvalidDataException(
+                    $"Non-contiguous sequence number '{entry.SequenceNumber}' detected after '{previousSequenceNumber}' while loading the hash-chained event log.");
+            }
+
+            previousSequenceNumber = entry.SequenceNumber;
 
             entries.Add(entry);
         }
@@ -481,6 +503,7 @@ public sealed class HashChainEventLog<TEvent>
 
     private string ComputeHash(LogEntry<TEvent> entry, string previousHash)
     {
+        // The hash payload must be serialized deterministically for stable verification.
         var eventPayload = _serializer.Serialize(entry.Event);
         var payload = string.Create(
             CultureInfo.InvariantCulture,

--- a/Picea/HashChainEventLog.cs
+++ b/Picea/HashChainEventLog.cs
@@ -1,0 +1,536 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Picea;
+
+/// <summary>
+/// Represents a single immutable hash-chained event-log entry.
+/// </summary>
+/// <typeparam name="TEvent">The event type.</typeparam>
+/// <param name="SequenceNumber">The 1-based event sequence number.</param>
+/// <param name="Timestamp">The timestamp when the event was appended.</param>
+/// <param name="Event">The captured event payload.</param>
+/// <param name="PreviousHash">The hash of the previous entry, or the anchor hash for the first entry.</param>
+/// <param name="Hash">The hash of this entry.</param>
+public readonly record struct HashChainLogEntry<TEvent>(
+    long SequenceNumber,
+    DateTimeOffset Timestamp,
+    TEvent Event,
+    string PreviousHash,
+    string Hash);
+
+/// <summary>
+/// Hashing options for hash-chained event logs.
+/// </summary>
+/// <param name="ComputeHash">Capability that computes the raw hash bytes for a payload.</param>
+/// <param name="EncodeHash">Capability that encodes hash bytes to a stable string representation.</param>
+/// <param name="AnchorHash">The chain anchor hash used as previous hash for the first entry.</param>
+public readonly record struct HashChainOptions(
+    Func<byte[], byte[]> ComputeHash,
+    Func<byte[], string> EncodeHash,
+    string AnchorHash)
+{
+    /// <summary>
+    /// Creates SHA-256 based hashing options.
+    /// </summary>
+    /// <param name="anchorHash">Optional anchor hash. Empty string by default.</param>
+    /// <returns>SHA-256 hashing options.</returns>
+    public static HashChainOptions Sha256(string anchorHash = "") =>
+        new(
+            ComputeHash: static payload => SHA256.HashData(payload),
+            EncodeHash: static hashBytes => Convert.ToHexString(hashBytes),
+            AnchorHash: anchorHash ?? string.Empty);
+}
+
+/// <summary>
+/// Storage capability for persisting and loading hash-chained event-log entries.
+/// </summary>
+/// <typeparam name="TEvent">The event type.</typeparam>
+/// <param name="SaveEntries">Persists the provided hash-chained entry stream.</param>
+/// <param name="LoadEntries">Loads a hash-chained entry stream from storage.</param>
+public readonly record struct HashChainLogStorage<TEvent>(
+    Func<IAsyncEnumerable<HashChainLogEntry<TEvent>>, CancellationToken, ValueTask> SaveEntries,
+    Func<CancellationToken, IAsyncEnumerable<HashChainLogEntry<TEvent>>> LoadEntries);
+
+/// <summary>
+/// Factory methods for common hash-chained event-log storage adapters.
+/// </summary>
+public static class HashChainLogStorage
+{
+    /// <summary>
+    /// Creates a JSON Lines file-based storage adapter for hash-chained entries.
+    /// </summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="path">The JSONL file path.</param>
+    /// <param name="serializer">The serializer capability.</param>
+    /// <returns>A storage adapter backed by a JSONL file.</returns>
+    public static HashChainLogStorage<TEvent> JsonLinesFile<TEvent>(string path, EventSerializer serializer)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        return new HashChainLogStorage<TEvent>(
+            SaveEntries: async (entries, cancellationToken) =>
+            {
+                var directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrWhiteSpace(directory))
+                    Directory.CreateDirectory(directory);
+
+                await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 16 * 1024, useAsync: true);
+                await using var writer = new StreamWriter(stream);
+
+                await foreach (var entry in entries.WithCancellation(cancellationToken).ConfigureAwait(false))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await writer.WriteLineAsync(serializer.Serialize(entry)).ConfigureAwait(false);
+                }
+            },
+            LoadEntries: cancellationToken => ReadEntries<TEvent>(path, serializer, cancellationToken));
+    }
+
+    private static async IAsyncEnumerable<HashChainLogEntry<TEvent>> ReadEntries<TEvent>(
+        string path,
+        EventSerializer serializer,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 16 * 1024, useAsync: true);
+        using var reader = new StreamReader(stream);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            if (line is null)
+                yield break;
+
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var entry = serializer.Deserialize<HashChainLogEntry<TEvent>>(line);
+            yield return entry;
+        }
+    }
+}
+
+/// <summary>
+/// Append-only hash-chained event log with replay, verification, and persistence APIs.
+/// </summary>
+/// <typeparam name="TEvent">The event type captured by the log.</typeparam>
+public sealed class HashChainEventLog<TEvent>
+{
+    private readonly Lock _sync = new();
+    private readonly EventSerializer _serializer;
+    private readonly HashChainOptions _hashing;
+    private readonly List<HashChainLogEntry<TEvent>> _entries;
+    private HashChainLogEntry<TEvent>[] _entriesSnapshot = Array.Empty<HashChainLogEntry<TEvent>>();
+    private IReadOnlyList<HashChainLogEntry<TEvent>> _entriesView = Array.Empty<HashChainLogEntry<TEvent>>();
+    private bool _snapshotDirty = true;
+    private string _currentHash;
+
+    /// <summary>
+    /// Initializes a new empty hash-chained event log.
+    /// </summary>
+    /// <param name="serializer">Optional serializer used for hash payload generation and persistence.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    public HashChainEventLog(EventSerializer? serializer = null, HashChainOptions? hashing = null)
+    {
+        _serializer = serializer ?? new JsonEventSerializer();
+        _hashing = ResolveHashing(hashing);
+        _entries = [];
+        _currentHash = _hashing.AnchorHash;
+    }
+
+    private HashChainEventLog(
+        List<HashChainLogEntry<TEvent>> entries,
+        EventSerializer serializer,
+        HashChainOptions hashing)
+    {
+        _entries = entries;
+        _serializer = serializer;
+        _hashing = hashing;
+        _currentHash = entries.Count is 0 ? hashing.AnchorHash : entries[^1].Hash;
+    }
+
+    /// <summary>
+    /// Returns a snapshot of all hash-chained entries in the log.
+    /// </summary>
+    public IReadOnlyList<HashChainLogEntry<TEvent>> Entries
+    {
+        get
+        {
+            lock (_sync)
+            {
+                RefreshSnapshotIfDirty();
+                return _entriesView;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of entries in the log.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_sync)
+                return _entries.Count;
+        }
+    }
+
+    /// <summary>
+    /// Returns the current head hash of the chain.
+    /// </summary>
+    public string CurrentHash
+    {
+        get
+        {
+            lock (_sync)
+                return _currentHash;
+        }
+    }
+
+    /// <summary>
+    /// Returns the chain anchor hash.
+    /// </summary>
+    public string AnchorHash => _hashing.AnchorHash;
+
+    /// <summary>
+    /// Returns the entry at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index.</param>
+    public HashChainLogEntry<TEvent> this[int index]
+    {
+        get
+        {
+            lock (_sync)
+                return _entries[index];
+        }
+    }
+
+    /// <summary>
+    /// Appends a new event to the hash-chained log.
+    /// </summary>
+    /// <param name="event">The event to append.</param>
+    /// <param name="timestamp">Optional timestamp. Uses UTC now when omitted.</param>
+    /// <returns>The appended hash-chained entry.</returns>
+    public HashChainLogEntry<TEvent> Append(TEvent @event, DateTimeOffset? timestamp = null)
+    {
+        lock (_sync)
+        {
+            var sequence = _entries.Count is 0 ? 1 : _entries[^1].SequenceNumber + 1;
+            var logEntry = new LogEntry<TEvent>(sequence, timestamp ?? DateTimeOffset.UtcNow, @event);
+            var previousHash = _currentHash;
+            var currentHash = ComputeHash(logEntry, previousHash);
+
+            var entry = new HashChainLogEntry<TEvent>(
+                logEntry.SequenceNumber,
+                logEntry.Timestamp,
+                logEntry.Event,
+                previousHash,
+                currentHash);
+
+            _entries.Add(entry);
+            _currentHash = currentHash;
+            _snapshotDirty = true;
+            return entry;
+        }
+    }
+
+    /// <summary>
+    /// Creates an append-only hash-chained event log and an observer that appends each transition event.
+    /// </summary>
+    /// <typeparam name="TState">The observed state type.</typeparam>
+    /// <typeparam name="TEffect">The observed effect type.</typeparam>
+    /// <param name="serializer">Optional serializer used for hash payload generation and persistence.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    /// <param name="timestampFactory">Optional timestamp factory used for each append.</param>
+    /// <returns>A tuple containing the observer and the backing hash-chained event log.</returns>
+    public static (Observer<TState, TEvent, TEffect> Observer, HashChainEventLog<TEvent> Log) Create<TState, TEffect>(
+        EventSerializer? serializer = null,
+        HashChainOptions? hashing = null,
+        Func<DateTimeOffset>? timestampFactory = null)
+    {
+        var log = new HashChainEventLog<TEvent>(serializer, hashing);
+        var now = timestampFactory ?? (() => DateTimeOffset.UtcNow);
+
+        Observer<TState, TEvent, TEffect> observer = (_, @event, _) =>
+        {
+            log.Append(@event, now());
+            return PipelineResult.Ok;
+        };
+
+        return (observer, log);
+    }
+
+    /// <summary>
+    /// Converts this hash-chained log into a standard event log snapshot.
+    /// </summary>
+    /// <returns>A snapshot-compatible event log.</returns>
+    public EventLog<TEvent> AsEventLog()
+    {
+        lock (_sync)
+        {
+            var entries = _entries.Count is 0
+                ? []
+                : new List<LogEntry<TEvent>>(_entries.Count);
+
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                var entry = _entries[i];
+                entries.Add(new LogEntry<TEvent>(entry.SequenceNumber, entry.Timestamp, entry.Event));
+            }
+
+            return EventLog<TEvent>.FromEntries(entries);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the full chain from the anchor to the current head.
+    /// </summary>
+    /// <returns>True when the full chain is valid; otherwise false.</returns>
+    public bool VerifyChain()
+    {
+        lock (_sync)
+            return VerifyChainFromAnchor(_hashing.AnchorHash);
+    }
+
+    /// <summary>
+    /// Verifies the chain segment between two sequence numbers, inclusive.
+    /// </summary>
+    /// <param name="fromSequenceNumber">The inclusive start sequence number.</param>
+    /// <param name="toSequenceNumber">The inclusive end sequence number.</param>
+    /// <returns>True when the segment is valid; otherwise false.</returns>
+    public bool VerifyRange(long fromSequenceNumber, long toSequenceNumber)
+    {
+        lock (_sync)
+            return VerifyRangeCore(fromSequenceNumber, toSequenceNumber, _hashing.AnchorHash);
+    }
+
+    /// <summary>
+    /// Verifies the full chain against a provided anchor hash.
+    /// </summary>
+    /// <param name="expectedAnchorHash">The expected anchor hash.</param>
+    /// <returns>True when the chain is valid for the provided anchor; otherwise false.</returns>
+    public bool VerifyAnchor(string expectedAnchorHash)
+    {
+        lock (_sync)
+            return VerifyChainFromAnchor(expectedAnchorHash ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Saves the hash-chained log to a JSON Lines file.
+    /// </summary>
+    /// <param name="path">The destination path.</param>
+    /// <param name="cancellationToken">Cancellation token for asynchronous saving.</param>
+    public async ValueTask SaveAsync(string path, CancellationToken cancellationToken = default) =>
+        await SaveAsync(HashChainLogStorage.JsonLinesFile<TEvent>(path, _serializer), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Saves the hash-chained log using the provided storage capability.
+    /// </summary>
+    /// <param name="storage">The storage capability.</param>
+    /// <param name="cancellationToken">Cancellation token for asynchronous saving.</param>
+    public async ValueTask SaveAsync(
+        HashChainLogStorage<TEvent> storage,
+        CancellationToken cancellationToken = default)
+    {
+        if (storage.SaveEntries is null)
+            throw new ArgumentException($"{nameof(HashChainLogStorage<TEvent>.SaveEntries)} cannot be null.", nameof(storage));
+
+        var snapshot = SnapshotEntries();
+        await storage.SaveEntries(AsAsyncEnumerable(snapshot, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads a hash-chained event log from a JSON Lines file.
+    /// </summary>
+    /// <param name="path">The source path.</param>
+    /// <param name="serializer">The serializer capability.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    /// <param name="cancellationToken">Cancellation token for asynchronous loading.</param>
+    /// <returns>The loaded hash-chained event log.</returns>
+    public static async ValueTask<HashChainEventLog<TEvent>> LoadAsync(
+        string path,
+        EventSerializer serializer,
+        HashChainOptions? hashing = null,
+        CancellationToken cancellationToken = default) =>
+        await LoadAsync(HashChainLogStorage.JsonLinesFile<TEvent>(path, serializer), serializer, hashing, cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <summary>
+    /// Loads a hash-chained event log using the provided storage capability.
+    /// </summary>
+    /// <param name="storage">The storage capability.</param>
+    /// <param name="serializer">The serializer capability.</param>
+    /// <param name="hashing">Optional hashing configuration. SHA-256 is used by default.</param>
+    /// <param name="cancellationToken">Cancellation token for asynchronous loading.</param>
+    /// <returns>The loaded hash-chained event log.</returns>
+    /// <exception cref="InvalidDataException">Thrown when sequence numbers are invalid.</exception>
+    public static async ValueTask<HashChainEventLog<TEvent>> LoadAsync(
+        HashChainLogStorage<TEvent> storage,
+        EventSerializer serializer,
+        HashChainOptions? hashing = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        if (storage.LoadEntries is null)
+            throw new ArgumentException($"{nameof(HashChainLogStorage<TEvent>.LoadEntries)} cannot be null.", nameof(storage));
+
+        var entries = new List<HashChainLogEntry<TEvent>>();
+        var sequenceNumbers = new HashSet<long>();
+
+        await foreach (var entry in storage.LoadEntries(cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (entry.SequenceNumber <= 0)
+                throw new InvalidDataException($"Invalid sequence number '{entry.SequenceNumber}'. Sequence numbers must be greater than zero.");
+
+            if (!sequenceNumbers.Add(entry.SequenceNumber))
+                throw new InvalidDataException($"Duplicate sequence number '{entry.SequenceNumber}' detected while loading the hash-chained event log.");
+
+            entries.Add(entry);
+        }
+
+        return new HashChainEventLog<TEvent>(entries, serializer, ResolveHashing(hashing));
+    }
+
+    private static HashChainOptions ResolveHashing(HashChainOptions? hashing)
+    {
+        var resolved = hashing ?? HashChainOptions.Sha256();
+
+        if (resolved.ComputeHash is null)
+            throw new ArgumentException($"{nameof(HashChainOptions.ComputeHash)} cannot be null.", nameof(hashing));
+
+        if (resolved.EncodeHash is null)
+            throw new ArgumentException($"{nameof(HashChainOptions.EncodeHash)} cannot be null.", nameof(hashing));
+
+        return resolved with { AnchorHash = resolved.AnchorHash ?? string.Empty };
+    }
+
+    private bool VerifyChainFromAnchor(string anchorHash)
+    {
+        if (_entries.Count is 0)
+            return string.Equals(anchorHash, _hashing.AnchorHash, StringComparison.Ordinal);
+
+        if (_entries[0].SequenceNumber != 1)
+            return false;
+
+        return VerifyRangeCore(1, _entries[^1].SequenceNumber, anchorHash);
+    }
+
+    private bool VerifyRangeCore(long fromSequenceNumber, long toSequenceNumber, string anchorHash)
+    {
+        if (fromSequenceNumber <= 0 || toSequenceNumber < fromSequenceNumber)
+            return false;
+
+        if (_entries.Count is 0)
+            return false;
+
+        var startIndex = IndexOfSequence(fromSequenceNumber);
+        var endIndex = IndexOfSequence(toSequenceNumber);
+
+        if (startIndex < 0 || endIndex < 0 || endIndex < startIndex)
+            return false;
+
+        string previousHash;
+        if (fromSequenceNumber is 1)
+        {
+            previousHash = anchorHash;
+        }
+        else
+        {
+            if (startIndex is 0)
+                return false;
+
+            var previousEntry = _entries[startIndex - 1];
+            if (previousEntry.SequenceNumber != fromSequenceNumber - 1)
+                return false;
+
+            previousHash = previousEntry.Hash;
+        }
+
+        var expectedSequence = fromSequenceNumber;
+        for (var i = startIndex; i <= endIndex; i++)
+        {
+            var entry = _entries[i];
+            if (entry.SequenceNumber != expectedSequence)
+                return false;
+
+            if (!string.Equals(entry.PreviousHash, previousHash, StringComparison.Ordinal))
+                return false;
+
+            var expectedHash = ComputeHash(
+                new LogEntry<TEvent>(entry.SequenceNumber, entry.Timestamp, entry.Event),
+                previousHash);
+
+            if (!string.Equals(entry.Hash, expectedHash, StringComparison.Ordinal))
+                return false;
+
+            previousHash = entry.Hash;
+            expectedSequence++;
+        }
+
+        return true;
+    }
+
+    private string ComputeHash(LogEntry<TEvent> entry, string previousHash)
+    {
+        var eventPayload = _serializer.Serialize(entry.Event);
+        var payload = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{entry.SequenceNumber}\n{entry.Timestamp:O}\n{previousHash}\n{eventPayload}");
+
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        var hashBytes = _hashing.ComputeHash(bytes);
+        return _hashing.EncodeHash(hashBytes);
+    }
+
+    private int IndexOfSequence(long sequenceNumber)
+    {
+        for (var i = 0; i < _entries.Count; i++)
+        {
+            if (_entries[i].SequenceNumber == sequenceNumber)
+                return i;
+        }
+
+        return -1;
+    }
+
+    private HashChainLogEntry<TEvent>[] SnapshotEntries()
+    {
+        lock (_sync)
+        {
+            RefreshSnapshotIfDirty();
+            return _entriesSnapshot;
+        }
+    }
+
+    private void RefreshSnapshotIfDirty()
+    {
+        if (!_snapshotDirty)
+            return;
+
+        _entriesSnapshot = _entries.Count is 0 ? Array.Empty<HashChainLogEntry<TEvent>>() : [.. _entries];
+        _entriesView = new ReadOnlyCollection<HashChainLogEntry<TEvent>>(_entriesSnapshot);
+        _snapshotDirty = false;
+    }
+
+    private static async IAsyncEnumerable<HashChainLogEntry<TEvent>> AsAsyncEnumerable(
+        IReadOnlyList<HashChainLogEntry<TEvent>> entries,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await ValueTask.CompletedTask;
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return entries[i];
+        }
+    }
+}

--- a/docs/concepts/event-log-replay-model.md
+++ b/docs/concepts/event-log-replay-model.md
@@ -56,6 +56,55 @@ See the practical guide: [Event Log Save, Load, And Replay (JSONL)](../guides/ev
 
 Core replay semantics are independent from any specific persistence technology.
 
+## Integrity Layer: Hash-Chained Event Logs
+
+For tamper-evidence, Picea provides a separate hash-chain mode via `HashChainEventLog<TEvent>` and `EventLog.CreateHashChain<TState, TEvent, TEffect>(...)`.
+
+Keep the boundary explicit:
+
+- Plain replay mode: `EventLog<TEvent>` for deterministic append/replay workflows.
+- Tamper-evidence mode: `HashChainEventLog<TEvent>` for append/replay plus hash-link verification.
+
+In hash-chain mode, each entry stores:
+
+- `PreviousHash` (link to prior entry, or anchor for the first entry)
+- `Hash` (hash over sequence number, timestamp, previous hash, and serialized event payload)
+
+Verification APIs:
+
+- `VerifyChain()` checks the full chain.
+- `VerifyRange(fromSequenceNumber, toSequenceNumber)` checks an inclusive segment.
+- `VerifyAnchor(expectedAnchorHash)` checks chain validity against an expected anchor.
+
+Practical notes:
+
+- `CurrentHash` exposes the current head hash for out-of-band recording.
+- `AsEventLog()` converts a verified hash-chained log into `EventLog<TEvent>` for standard replay APIs.
+
+## Non-Goals And Guarantee Boundaries
+
+Hash chaining in Picea is tamper-evidence, not a complete trust system.
+
+Non-goals:
+
+- It is not encryption.
+- It is not digital signing or identity attestation.
+- It is not distributed consensus.
+
+What it does provide:
+
+- Detection of common log mutation classes (insert/delete/reorder/edit) when the verifier has a trusted anchor or trusted head hash.
+
+What it does not provide by itself:
+
+- Who performed a change.
+- Confidentiality of event payloads.
+- Byzantine fault tolerance.
+
+Recommendation:
+
+- Anchor periodically by storing `CurrentHash` in a separate trust domain (for example: append-only audit store, external timestamp/signing service, or independent operational system). Without anchoring, verification still checks internal consistency, but trust remains local to the same system boundary.
+
 ## Storage Abstraction
 
 Persistence is modeled as a capability, not built into replay itself:

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,7 +10,7 @@ Deep-dive explanations of the core ideas behind Picea. Read these to understand 
 | ------- | ---------------- |
 | [The Kernel](the-kernel.md) | The Mealy machine interface — `Initialize` + `Transition` |
 | [The Runtime](the-runtime.md) | The monadic left fold — Observer + Interpreter |
-| [Event Log Observer And Replay Model](event-log-replay-model.md) | Append-only event capture and deterministic replay model |
+| [Event Log Observer And Replay Model](event-log-replay-model.md) | Plain replay model plus hash-chain tamper-evidence boundaries |
 | [The Decider](the-decider.md) | Command validation — `Decide` + `IsTerminal` |
 | [Composition](composition.md) | How automata compose — product, sum, feedback |
 | [Runtimes Compared](runtimes-compared.md) | MVU vs Event Sourcing vs Actor — when to use which |

--- a/docs/guides/event-log-save-load-replay.md
+++ b/docs/guides/event-log-save-load-replay.md
@@ -169,6 +169,14 @@ await hashLog.SaveAsync(storage);
 var loadedHashLog = await HashChainEventLog<CounterEvent>.LoadAsync(storage, serializer, hashing);
 ```
 
+### Hash-Chain JSONL Shape
+
+Hash-chain storage includes integrity metadata per line (`previousHash` and `hash`):
+
+```json
+{"sequenceNumber":1,"timestamp":"2026-04-06T12:34:56.0000000+00:00","event":{"kind":"Increment"},"previousHash":"","hash":"7EA7D5A9C8..."}
+```
+
 ### Verify Before Replay
 
 ```csharp
@@ -202,7 +210,7 @@ Hash-chaining provides tamper-evidence. It does not provide:
 
 ## JSONL Shape
 
-Default JSONL storage writes one entry per line:
+Default plain `EventLog<TEvent>` JSONL storage writes one entry per line:
 
 ```json
 {"sequenceNumber":1,"timestamp":"2026-04-06T12:34:56.0000000+00:00","event":{"kind":"Increment"}}

--- a/docs/guides/event-log-save-load-replay.md
+++ b/docs/guides/event-log-save-load-replay.md
@@ -22,6 +22,13 @@ Keep this distinction clear:
 
 The default storage adapter is JSONL via `EventLogStorage.JsonLinesFile<TEvent>(...)`.
 
+## Plain Replay vs Tamper-Evidence Mode
+
+Use plain mode when you only need deterministic replay. Use hash-chain mode when you also need tamper-evidence checks.
+
+- Plain mode APIs: `EventLog.Create(...)`, `EventLog.LoadAsync(...)`, `EventLog<TEvent>.Replay(...)`
+- Tamper-evidence APIs: `EventLog.CreateHashChain(...)`, `EventLog.LoadHashChainAsync(...)`, `HashChainEventLog<TEvent>.VerifyChain()`
+
 ## 1. Create Observer + Event Log
 
 ```csharp
@@ -124,6 +131,74 @@ static async IAsyncEnumerable<LogEntry<CounterEvent>> LoadFromMemory(
 ```
 
 Cloud-style capability follows the same shape: `SaveEntries` writes each `LogEntry<TEvent>` to your service, `LoadEntries` streams entries back for replay.
+
+## 6. Hash-Chain Tamper-Evidence Workflow
+
+The hash-chain workflow keeps replay semantics and adds explicit integrity checks.
+
+### Create Hash-Chain Observer + Log
+
+```csharp
+var serializer = new JsonEventSerializer();
+var hashing = HashChainOptions.Sha256(anchorHash: "audit-anchor-v1");
+
+var (hashObserver, hashLog) = EventLog.CreateHashChain<CounterState, CounterEvent, CounterEffect>(
+    serializer,
+    hashing);
+
+var observer = hashObserver.Then(metricsObserver).Then(renderObserver);
+```
+
+### Save And Load Hash-Chain Log
+
+```csharp
+await hashLog.SaveAsync("session.hash.jsonl");
+
+var loadedHashLog = await EventLog.LoadHashChainAsync<CounterEvent>(
+    "session.hash.jsonl",
+    serializer,
+    hashing);
+```
+
+Equivalent explicit storage-capability form:
+
+```csharp
+var storage = HashChainLogStorage.JsonLinesFile<CounterEvent>("session.hash.jsonl", serializer);
+
+await hashLog.SaveAsync(storage);
+var loadedHashLog = await HashChainEventLog<CounterEvent>.LoadAsync(storage, serializer, hashing);
+```
+
+### Verify Before Replay
+
+```csharp
+if (!loadedHashLog.VerifyChain())
+{
+    throw new InvalidDataException("Hash-chain verification failed.");
+}
+
+var anchorMatches = loadedHashLog.VerifyAnchor(hashing.AnchorHash);
+var rangeMatches = loadedHashLog.Count is 0
+    ? anchorMatches
+    : loadedHashLog.VerifyRange(1, loadedHashLog.Entries[^1].SequenceNumber);
+
+var replayLog = loadedHashLog.AsEventLog();
+var finalState = replayLog.Replay<Counter, CounterState, CounterEffect, Unit>(default);
+```
+
+### Anchor Recommendation
+
+`CurrentHash` is the chain head hash. Record it outside the primary system boundary on a schedule (or at key checkpoints) so later verification can compare against a trusted external value.
+
+Without external anchoring, hash-chain verification still provides internal consistency checks, but trust does not extend beyond the same storage boundary.
+
+### Non-Goals
+
+Hash-chaining provides tamper-evidence. It does not provide:
+
+- Encryption
+- Digital signatures and signer identity
+- Distributed consensus
 
 ## JSONL Shape
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,7 +10,7 @@ Practical recipes for common tasks. Each guide solves a specific problem.
 | ----- | -------------- |
 | [Building Custom Runtimes](building-custom-runtimes.md) | How to wire your own Observer + Interpreter |
 | [Error Handling Patterns](error-handling-patterns.md) | Map, Bind, MapError pipelines with Result |
-| [Event Log Save, Load, And Replay (JSONL)](event-log-save-load-replay.md) | Deterministic session replay workflow with JSON Lines |
+| [Event Log Save, Load, And Replay (JSONL)](event-log-save-load-replay.md) | Deterministic replay and hash-chain tamper-evidence workflow |
 | [Observer Composition](observer-composition.md) | Then, Where, Catch, Combine recipes |
 | [Testing Strategies](testing-strategies.md) | Testing at every level: pure functions, runtime, integration |
 | [Upgrading to Decider](upgrading-to-decider.md) | Adding command validation to an existing Automaton |

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,5 +64,5 @@ This follows the [Diataxis](https://diataxis.fr/) documentation framework.
 
 ## Additional Reading
 
-- [Event Log Observer And Replay Model](concepts/event-log-replay-model.md)
-- [Event Log Save, Load, And Replay (JSONL)](guides/event-log-save-load-replay.md)
+- [Event Log Observer And Replay Model](concepts/event-log-replay-model.md) (plain replay semantics and hash-chain integrity boundaries)
+- [Event Log Save, Load, And Replay (JSONL)](guides/event-log-save-load-replay.md) (plain mode and tamper-evidence usage examples)


### PR DESCRIPTION
## What
- add optional hash-chain integrity logging via `HashChainEventLog<TEvent>`
- add static entry points `EventLog.CreateHashChain<...>()` and `EventLog.LoadHashChainAsync<...>()`
- add verification APIs: full chain, range, and anchor checks
- add `CurrentHash` and `AsEventLog()` interoperability
- add persistence support for hash-chained entries (`HashChainLogStorage` + JSONL adapter)
- expand tests for tamper detection, verification behavior, and replay parity
- update docs for integrity mode usage and non-goals

## Why
- provide tamper-evidence for audit/compliance scenarios while preserving plain EventLog replay semantics
- keep integrity mode additive and backward-compatible with existing EventLog APIs

## Testing
- dotnet build Picea.sln
- focused EventLog tests (hash-chain scenarios) via runTests

Closes #36
