### PR TITLE
fix(release): set version to 1.0.0 for exact NBGV patch version

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## What
Change `version.json` from `"1.0"` to `"1.0.0"`.

## Why
NBGV with `"1.0"` appends commit height as the patch digit (e.g. `1.0.50`).
With `"1.0.0"` it produces exactly `1.0.0` on any public release ref (`main`).

## Validation
`nbgv get-version -v NuGetPackageVersion` returns `1.0.0` locally.