### PR TITLE
fix(release): add tag ref to publicReleaseRefSpec for clean NuGet version on tag builds

### DIFF
--- a/version.json
+++ b/version.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0.0",
   "publicReleaseRefSpec": [
-    "^refs/heads/main$"
+    "^refs/heads/main$",
+    "^refs/tags/v\\d+\\.\\d+\\.\\d+$"
   ],
   "cloudBuild": {
     "setVersionVariables": true,


### PR DESCRIPTION
## What
Add `^refs/tags/v\d+\.\d+\.\d+$` to `publicReleaseRefSpec` in `version.json`.

## Why
When the release workflow checks out a tag (`refs/tags/v1.0.0`), NBGV's existing `publicReleaseRefSpec` only matched `refs/heads/main`. Without a matching entry for the tag ref, NBGV appended the git commit hash suffix (e.g. `1.0.0-g5aff12c547`) instead of producing a clean `1.0.0`.

## Validation
`nbgv get-version -v NuGetPackageVersion` returns `1.0.0` locally. CI on the tag ref will now also match and strip the hash.