### PR TITLE
fix(release): narrow Picea NuGet glob to exclude Templates package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,4 +109,4 @@ jobs:
           dotnet nuget push ./nupkg/Picea.Templates.*.nupkg --api-key "$API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Publish Picea to NuGet
-        run: dotnet nuget push ./nupkg/Picea.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "./nupkg/Picea.[0-9]*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What
Change `./nupkg/Picea.*.nupkg` to `./nupkg/Picea.[0-9]*.nupkg` in the Publish Picea step.

## Why
The wildcard `Picea.*` also matches `Picea.Templates.1.0.0.nupkg`. The Templates step already pushes that package with its dedicated key; the Picea step then retried with `NUGET_API_KEY` causing a 403.

Using `[0-9]` as the first character after `Picea.` reliably targets only the versioned `Picea.1.0.0.nupkg` package (version numbers always start with a digit, `Templates` starts with T).

## Validation
`Picea.1.0.0` was confirmed published successfully in the previous run (HTTP 201). This change prevents the spurious 403 on the Templates re-push.