### PR TITLE
fix(release): use find to locate Picea package instead of bracket glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,4 +109,6 @@ jobs:
           dotnet nuget push ./nupkg/Picea.Templates.*.nupkg --api-key "$API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Publish Picea to NuGet
-        run: dotnet nuget push "./nupkg/Picea.[0-9]*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          PKG=$(find ./nupkg -maxdepth 1 -name "Picea.*.nupkg" ! -name "Picea.Templates.*" | head -1)
+          dotnet nuget push "$PKG" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What
Replace `dotnet nuget push "./nupkg/Picea.[0-9]*.nupkg"` with a `find` command to locate the package excluding Templates.

## Why
Double-quoted glob in bash disables expansion — `[0-9]` was passed literally to `dotnet nuget push`, which couldn't find the file. Using `find ... ! -name "Picea.Templates.*"` reliably selects only the core Picea package.

## Validation
Previous run confirmed `Picea.1.0.0` was pushed successfully (HTTP 201). This only fixes the glob mechanics.